### PR TITLE
Fix Portuguese home description typo

### DIFF
--- a/public/locales/pt/traducao.json
+++ b/public/locales/pt/traducao.json
@@ -1,7 +1,7 @@
 {
   "Home": {
     "title": "Olá mundo!",
-    "description": "Esta é uma descrição graaande XD Se você gosta desse tipo de conteúdo, por favor, inscreva-se no meu canal",
+    "description": "Esta é uma descrição grande XD Se você gosta desse tipo de conteúdo, por favor, inscreva-se no meu canal",
     "client": "LADO DO CLIENTE",
     "prev": "anterior",
     "next": "próximo"


### PR DESCRIPTION
## Summary
- fix spelling of "grande" in Portuguese translation

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685605dacb8c83308af3cc4ce9b859a1