### PR TITLE
Enable dark mode detection for d: variant

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,20 @@ import reportWebVitals from './reportWebVitals';
 import './i18n/i18n';
 import { cn } from "./lib/utils"; // importe a função cn
 
+// Determine the initial theme before React renders
+const storedTheme = typeof window !== "undefined" ? localStorage.getItem("theme") : null;
+const prefersDark = typeof window !== "undefined" && window.matchMedia("(prefers-color-scheme: dark)").matches;
+const isDark = storedTheme ? storedTheme === "dark" : prefersDark;
+
+if (typeof window !== "undefined") {
+  const root = window.document.documentElement;
+  if (isDark) {
+    root.classList.add("dark");
+  } else {
+    root.classList.remove("dark");
+  }
+}
+
 document.body.className = cn(
   "color-gray--slate bg-white [--line-color:theme(colors.gray.200/0.8)] d:bg-gray-900 d:bg-gradient-to-b d:from-black/40 d:to-black/40"
 );


### PR DESCRIPTION
## Summary
- ensure the `dark` class is applied on initial render

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580cf6ee7083308ce9044e083180e2